### PR TITLE
writing to named pipe - buffering policy set to line buffering

### DIFF
--- a/nscaweb/communication.py
+++ b/nscaweb/communication.py
@@ -282,7 +282,7 @@ class DeliverNamedPipe(threading.Thread):
             if os.path.exists(self.location):
                 mode = os.stat(self.location)[ST_MODE]
                 if S_ISFIFO(mode):
-                    cmd=open(self.location,'w')
+                    cmd=open(self.location,'w', buffering=1)
                     if len(self.data) == 1:
                         cmd.write(self.data[0].encode('utf-8')+'\n')
                     else:


### PR DESCRIPTION
Writes data to a local named pipe may be splited in wrong place

[1455020732] Error: External command failed -> PROCESS_SERVICE_CHECK_RESULT;db1;mysql_
[1455020732] External command error: Command failed
[1455020732] External command error: Malformed command

sent command:
[1455020732] PROCESS_SERVICE_CHECK_RESULT;db1;mysql_backup;0;OK
